### PR TITLE
Fixing cyclic dependency on lightning

### DIFF
--- a/lightning_api_access/APIAccessFrontend.py
+++ b/lightning_api_access/APIAccessFrontend.py
@@ -2,7 +2,12 @@ import json
 import os
 from typing import Any, Dict, List
 
-from lightning.app.frontend import StaticWebFrontend
+try:
+    from lightning.app.frontend import StaticWebFrontend
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        f"Lightning is a required dependency for this component. Please run: pip install lightning"
+    )
 
 
 class APIAccessFrontend(StaticWebFrontend):
@@ -29,7 +34,8 @@ class APIAccessFrontend(StaticWebFrontend):
         super().__init__(ui_dir)
 
         # Write API metadata to a JSON file
-        # Note: This will deliberately be performed each time the `APIAccessFrontend` so that the metadata can change dynamically without issues
+        # Note: This will deliberately be performed each time the `APIAccessFrontend` so that
+        # the metadata can change dynamically without issues
         self.metadata_file = os.path.join(ui_dir, "api_metadata.json")
         with open(self.metadata_file, "w") as f:
             json.dump({"apis": apis}, f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-lightning


### PR DESCRIPTION
Since this package is currently required by the lightning itself (by the serve component) and also has a dependency on lightning, the cyclic dependency is created. This PR removes the `lightning` dependency from this package and lazily check if lightning is installed or not